### PR TITLE
basic support for custom formats defined in files

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,16 +36,18 @@ $ ./panelgen -format=pulplogic -reference-board=data/ref.brd -output=mytile.brd 
 ## commandline options
 
 ```
-$ ./panelgen --help
+$ ./panelgen -help
 Usage of ./panelgen:
   -format string
-    	panel format to create (eurorack, pulplogic, intellijel) (default "eurorack")
+    	panel format to create (eurorack,pulplogic,intellijel,spec) (default "eurorack")
   -outline-layer string
     	layer to draw board outline in (default "Dimension")
   -output string
     	filename to write new Eagle board file to (default "newpanel.brd")
   -reference-board string
     	reference Eagle board file to read layer information from
+  -spec-file string
+    	filename to read YAML panel spec from
   -width int
     	width of the panel, in integer units appropriate for the format (default 4)
 ```
@@ -144,10 +146,32 @@ many earlier versions also!) but are _not_ accepted by
 is, but it's most likely *not* OSHPark's fault, so please *don't* complain to
 them if you try to use this. Just generate some Gerber files instead.
 
+# custom panel specifications
+
+These are now supported by `panelgen`, and are defined in YAML files that look
+like the below:
+
+    name: testEnclosure
+    width: 100.0
+    height: 75.0
+    horizontalFit: 0.0
+    mountingHoleDiameter: 3.1
+    mountingHoles:
+      - { x: 10, y: 10 }
+      - { x: 90, y: 10 }
+      - { x: 10, y: 65 }
+      - { x: 90, y: 65 }
+
+Usage:
+
+    $ ./panelgen -format=spec -spec-file=enclosures/spec-test.yaml \
+      -reference-board=data/ref.brd -output=test.brd
+
 # to-do
 
 * exhaustively scan the Eagle DTD and add the various missing items (libraries!)
-* ability to define custom panel formats, eg. to fit a specific custom enclosure
+* extend custom panel spec support to increasingly terribly-named `schroff` tool
+* panel corner radius support, to better fit common box enclosures
 * BOM generation tool
 
 # copyright

--- a/README.md
+++ b/README.md
@@ -1,13 +1,22 @@
 # overview
 
-This repository contains code and tools for interacting with Autodesk Eagle files.
+This repository contains code and tools for interacting with Autodesk Eagle
+files, and particularly for creating Eagle board files that can be used to
+manufacture front panels for electronics. Originally this was intended for
+Eurorack synthesizer systems, but now also has crude support for custom
+enclosures, such as the ubiquitous plastic "jiffy boxes".
 
 At present, the below tools are included:
 
-* `panelgen`: create a new blank panel board file in Eurorack, Pulplogic 1U or
-  Intellijel 1U formats, at a specified width
-* `schroff`: derive a new Eurorack panel board file from the board file for
-  your circuit
+* `panelgen`: create a new blank panel board file
+* `schroff`: derive a new panel board file from the board file for your circuit
+
+The below panel formats are supported:
+
+* Eurorack 3U, per Doepfer spec
+* Pulplogic 1U, per Pulplogic spec
+* Intellijel 1U, per Intellijel spec
+* custom enclosure specs defined in a YAML file
 
 # installing
 
@@ -18,7 +27,6 @@ and `schroff` commands:
 brew tap jsleeio/apps
 brew install go-eagle
 ```
-
 
 # panelgen
 
@@ -139,8 +147,8 @@ them if you try to use this. Just generate some Gerber files instead.
 
 # custom panel specifications
 
-These are now supported by `panelgen`, and are defined in YAML files that look
-like the below:
+These are now supported by `panelgen` and `schroff`, and are defined in YAML
+files that look like the below:
 
     name: testEnclosure
     width: 100.0
@@ -153,17 +161,27 @@ like the below:
       - { x: 10, y: 65 }
       - { x: 90, y: 65 }
 
-Usage:
+Usage wth `panelgen`:
 
     $ ./panelgen -format=spec -spec-file=enclosures/spec-test.yaml \
       -reference-board=data/ref.brd -output=test.brd
 
+Usage with `schroff`:
+
+    $ ./schroff -format=spec -spec-file=enclosure.yaml test.brd
+
+This is extremely preliminary at presejt
+
 # to-do
 
 * exhaustively scan the Eagle DTD and add the various missing items (libraries!)
-* extend custom panel spec support to increasingly terribly-named `schroff` tool
 * panel corner radius support, to better fit common box enclosures
 * BOM generation tool
+* custom panel format should support defining a list of keepouts in at least
+  rectangular and circular shapes
+* a tool to generate an Eagle library for a custom enclosure, including keepouts
+  and cutouts features inside the case, and a Dimension layer outline. This
+  would be useful for a layout quick-start on the PCB to go inside the enclosure
 
 # copyright
 

--- a/README.md
+++ b/README.md
@@ -88,12 +88,12 @@ attribute name                    | type      | default value    | purpose
 `PANEL_LEGEND_OFFSET_Y`           | component | `0.0`            | nudge panel legend text up or down (millimetres)
 `PANEL_LEGEND_TICKS`              | component | `no`             | set to `yes` to add tick marks around component hole, eg. for potentiometers
 `PANEL_LEGEND_TICKS_COUNT`        | component | `11`             | number of ticks to draw
-`PANEL_LEGEND_TICKS_END_ANGLE`    | component | `225.0`          | ending polar angle to which to draw ticks, in degrees. Zero degrees is at 9 o'clock
-`PANEL_LEGEND_TICKS_LENGTH`       | component | `2.0`            | length of ticks
+`PANEL_LEGEND_TICKS_END_ANGLE`    | component | `240.0`          | ending polar angle to which to draw ticks, in degrees. Zero degrees is at 9 o'clock
+`PANEL_LEGEND_TICKS_LENGTH`       | component | `1.5`            | length of ticks
 `PANEL_LEGEND_TICKS_LABELS`       | component | `no`             | set to `yes` to add text labels next to tick marks
 `PANEL_LEGEND_TICKS_LABELS_TEXTS` | component | _none_           | labels for tick marks, separated with `,`. Quantity must match `PANEL_LEGEND_TICKS_COUNT`
-`PANEL_LEGEND_TICKS_START_ANGLE`  | component | `-45.0`          | starting polar angle from which to draw ticks, in degrees. Zero degrees is at 9 o'clock
-`PANEL_LEGEND_TICKS_WIDTH`        | component | `0.5`            | width of ticks
+`PANEL_LEGEND_TICKS_START_ANGLE`  | component | `-60.0`          | starting polar angle from which to draw ticks, in degrees. Zero degrees is at 9 o'clock
+`PANEL_LEGEND_TICKS_WIDTH`        | component | `0.25`           | width of ticks
 `PANEL_LEGEND`                    | component | _component name_ | override panel legend text for a component
 
 ## commandline options

--- a/README.md
+++ b/README.md
@@ -69,23 +69,32 @@ Components that need panel holes must have a `PANEL_DRILL_MM` attribute.
 
 ## list of global and component attributes
 
-attribute name          | type      | default value    | purpose
------------------------ | --------- | ---------------- | --------------------------------------------------------------------
-`PANEL_HEADER_LAYER`    | global    | `tStop`          | layer to place header text on
-`PANEL_HEADER_OFFSET_X` | global    | `0.0`            | nudge panel header text left or right (millimetres)
-`PANEL_HEADER_OFFSET_Y` | global    | `0.0`            | nudge panel header text up or down (millimetres)
-`PANEL_HEADER_TEXT`     | global    | `<HEADER_TEXT>`  | text for header section of panel
-`PANEL_FOOTER_LAYER`    | global    | `tStop`          | layer to place footer text on
-`PANEL_FOOTER_OFFSET_X` | global    | `0.0`            | nudge panel footer text left or right (millimetres)
-`PANEL_FOOTER_OFFSET_Y` | global    | `0.0`            | nudge panel footer text up or down (millimetres)
-`PANEL_FOOTER_TEXT`     | global    | `<FOOTER_TEXT>`  | text for footer section of panel
-`PANEL_LEGEND_LAYER`    | global    | `tStop`          | layer to place panel legend text on
-`PANEL_LEGEND_SKIP_RE`  | global    | _none_           | [RE2](https://github.com/google/re2/wiki/Syntax) expression; if a component name matches, legend text is skipped
-`PANEL_DRILL_MM`        | component | _none_           | panel drill size to create for a component. Required for drill holes.
-`PANEL_LEGEND`          | component | _component name_ | override panel legend text for a component
-`PANEL_LEGEND_OFFSET_X` | component | `0.0`            | nudge panel legend text left or right (millimetres)
-`PANEL_LEGEND_OFFSET_Y` | component | `0.0`            | nudge panel legend text up or down (millimetres)
-`PANEL_HOLE_STOP_WIDTH` | component | `2.0`            | override the width of the stop-mask ring around the component hole
+attribute name                    | type      | default value    | purpose
+--------------------------------- | --------- | ---------------- | --------------------------------------------------------------------
+`PANEL_HEADER_LAYER`              | global    | `tStop`          | layer to place header text on
+`PANEL_HEADER_OFFSET_X`           | global    | `0.0`            | nudge panel header text left or right (millimetres)
+`PANEL_HEADER_OFFSET_Y`           | global    | `0.0`            | nudge panel header text up or down (millimetres)
+`PANEL_HEADER_TEXT`               | global    | `<HEADER_TEXT>`  | text for header section of panel
+`PANEL_FOOTER_LAYER`              | global    | `tStop`          | layer to place footer text on
+`PANEL_FOOTER_OFFSET_X`           | global    | `0.0`            | nudge panel footer text left or right (millimetres)
+`PANEL_FOOTER_OFFSET_Y`           | global    | `0.0`            | nudge panel footer text up or down (millimetres)
+`PANEL_FOOTER_TEXT`               | global    | `<FOOTER_TEXT>`  | text for footer section of panel
+`PANEL_LEGEND_LAYER`              | global    | `tStop`          | layer to place panel legend text on
+`PANEL_LEGEND_SKIP_RE`            | global    | _none_           | [RE2](https://github.com/google/re2/wiki/Syntax) expression; if a component name matches, legend text is skipped
+`PANEL_DRILL_MM`                  | component | _none_           | panel drill size to create for a component. Required for drill holes.
+`PANEL_HOLE_STOP_WIDTH`           | component | `2.0`            | override the width of the stop-mask ring around the component hole
+`PANEL_LEGEND_LOCATION`           | component | `above`          | set to `below` to place the legend text `below` the component instead of `above`
+`PANEL_LEGEND_OFFSET_X`           | component | `0.0`            | nudge panel legend text left or right (millimetres)
+`PANEL_LEGEND_OFFSET_Y`           | component | `0.0`            | nudge panel legend text up or down (millimetres)
+`PANEL_LEGEND_TICKS`              | component | `no`             | set to `yes` to add tick marks around component hole, eg. for potentiometers
+`PANEL_LEGEND_TICKS_COUNT`        | component | `11`             | number of ticks to draw
+`PANEL_LEGEND_TICKS_END_ANGLE`    | component | `225.0`          | ending polar angle to which to draw ticks, in degrees. Zero degrees is at 9 o'clock
+`PANEL_LEGEND_TICKS_LENGTH`       | component | `2.0`            | length of ticks
+`PANEL_LEGEND_TICKS_LABELS`       | component | `no`             | set to `yes` to add text labels next to tick marks
+`PANEL_LEGEND_TICKS_LABELS_TEXTS` | component | _none_           | labels for tick marks, separated with `,`. Quantity must match `PANEL_LEGEND_TICKS_COUNT`
+`PANEL_LEGEND_TICKS_START_ANGLE`  | component | `-45.0`          | starting polar angle from which to draw ticks, in degrees. Zero degrees is at 9 o'clock
+`PANEL_LEGEND_TICKS_WIDTH`        | component | `0.5`            | width of ticks
+`PANEL_LEGEND`                    | component | _component name_ | override panel legend text for a component
 
 ## commandline options
 

--- a/README.md
+++ b/README.md
@@ -36,16 +36,18 @@ $ ./panelgen -format=pulplogic -reference-board=data/ref.brd -output=mytile.brd 
 ## commandline options
 
 ```
-$ ./panelgen --help
+$ ./panelgen -help
 Usage of ./panelgen:
   -format string
-    	panel format to create (eurorack, pulplogic, intellijel) (default "eurorack")
+    	panel format to create (eurorack,pulplogic,intellijel,spec) (default "eurorack")
   -outline-layer string
     	layer to draw board outline in (default "Dimension")
   -output string
     	filename to write new Eagle board file to (default "newpanel.brd")
   -reference-board string
     	reference Eagle board file to read layer information from
+  -spec-file string
+    	filename to read YAML panel spec from
   -width int
     	width of the panel, in integer units appropriate for the format (default 4)
 ```
@@ -135,10 +137,32 @@ many earlier versions also!) but are _not_ accepted by
 is, but it's most likely *not* OSHPark's fault, so please *don't* complain to
 them if you try to use this. Just generate some Gerber files instead.
 
+# custom panel specifications
+
+These are now supported by `panelgen`, and are defined in YAML files that look
+like the below:
+
+    name: testEnclosure
+    width: 100.0
+    height: 75.0
+    horizontalFit: 0.0
+    mountingHoleDiameter: 3.1
+    mountingHoles:
+      - { x: 10, y: 10 }
+      - { x: 90, y: 10 }
+      - { x: 10, y: 65 }
+      - { x: 90, y: 65 }
+
+Usage:
+
+    $ ./panelgen -format=spec -spec-file=enclosures/spec-test.yaml \
+      -reference-board=data/ref.brd -output=test.brd
+
 # to-do
 
 * exhaustively scan the Eagle DTD and add the various missing items (libraries!)
-* ability to define custom panel formats, eg. to fit a specific custom enclosure
+* extend custom panel spec support to increasingly terribly-named `schroff` tool
+* panel corner radius support, to better fit common box enclosures
 * BOM generation tool
 
 # copyright

--- a/README.md
+++ b/README.md
@@ -1,13 +1,22 @@
 # overview
 
-This repository contains code and tools for interacting with Autodesk Eagle files.
+This repository contains code and tools for interacting with Autodesk Eagle
+files, and particularly for creating Eagle board files that can be used to
+manufacture front panels for electronics. Originally this was intended for
+Eurorack synthesizer systems, but now also has crude support for custom
+enclosures, such as the ubiquitous plastic "jiffy boxes".
 
 At present, the below tools are included:
 
-* `panelgen`: create a new blank panel board file in Eurorack, Pulplogic 1U or
-  Intellijel 1U formats, at a specified width
-* `schroff`: derive a new Eurorack panel board file from the board file for
-  your circuit
+* `panelgen`: create a new blank panel board file
+* `schroff`: derive a new panel board file from the board file for your circuit
+
+The below panel formats are supported:
+
+* Eurorack 3U, per Doepfer spec
+* Pulplogic 1U, per Pulplogic spec
+* Intellijel 1U, per Intellijel spec
+* custom enclosure specs defined in a YAML file
 
 # installing
 
@@ -18,7 +27,6 @@ and `schroff` commands:
 brew tap jsleeio/apps
 brew install go-eagle
 ```
-
 
 # panelgen
 
@@ -148,8 +156,8 @@ them if you try to use this. Just generate some Gerber files instead.
 
 # custom panel specifications
 
-These are now supported by `panelgen`, and are defined in YAML files that look
-like the below:
+These are now supported by `panelgen` and `schroff`, and are defined in YAML
+files that look like the below:
 
     name: testEnclosure
     width: 100.0
@@ -162,17 +170,27 @@ like the below:
       - { x: 10, y: 65 }
       - { x: 90, y: 65 }
 
-Usage:
+Usage wth `panelgen`:
 
     $ ./panelgen -format=spec -spec-file=enclosures/spec-test.yaml \
       -reference-board=data/ref.brd -output=test.brd
 
+Usage with `schroff`:
+
+    $ ./schroff -format=spec -spec-file=enclosure.yaml test.brd
+
+This is extremely preliminary at presejt
+
 # to-do
 
 * exhaustively scan the Eagle DTD and add the various missing items (libraries!)
-* extend custom panel spec support to increasingly terribly-named `schroff` tool
 * panel corner radius support, to better fit common box enclosures
 * BOM generation tool
+* custom panel format should support defining a list of keepouts in at least
+  rectangular and circular shapes
+* a tool to generate an Eagle library for a custom enclosure, including keepouts
+  and cutouts features inside the case, and a Dimension layer outline. This
+  would be useful for a layout quick-start on the PCB to go inside the enclosure
 
 # copyright
 

--- a/cmd/schroff/schroff.go
+++ b/cmd/schroff/schroff.go
@@ -189,11 +189,12 @@ func elementConfigFromElement(elem eagle.Element) (elementConfig, error) {
 		return ec, err
 	}
 	// default values for start and end angles suit a typical single-turn potentiometer
-	// with a 270-degree rotation
-	if ec.ticksStartAngle, err = eagle.AttributeFloat(elem, "PANEL_LEGEND_TICKS_START_ANGLE", -45.0); err != nil {
+	// with a 300-degree rotation, like Alpha 9mm vertical pots
+	// https://www.thonk.co.uk/documents/alpha/9mm/Alpha%209mm%20Vertical%20-%20Linear%20Taper%20B1K-B500K.pdf
+	if ec.ticksStartAngle, err = eagle.AttributeFloat(elem, "PANEL_LEGEND_TICKS_START_ANGLE", -60.0); err != nil {
 		return ec, err
 	}
-	if ec.ticksEndAngle, err = eagle.AttributeFloat(elem, "PANEL_LEGEND_TICKS_END_ANGLE", 225.0); err != nil {
+	if ec.ticksEndAngle, err = eagle.AttributeFloat(elem, "PANEL_LEGEND_TICKS_END_ANGLE", 240.0); err != nil {
 		return ec, err
 	}
 	// everything should go up to (at least) 11

--- a/cmd/schroff/schroff.go
+++ b/cmd/schroff/schroff.go
@@ -26,11 +26,13 @@ import (
 	"log"
 	"path/filepath"
 	"regexp"
+	"strings"
 
 	"github.com/jsleeio/go-eagle/pkg/eagle"
 	"github.com/jsleeio/go-eagle/pkg/format/eurorack"
 	"github.com/jsleeio/go-eagle/pkg/format/intellijel"
 	"github.com/jsleeio/go-eagle/pkg/format/pulplogic"
+	"github.com/jsleeio/go-eagle/pkg/geometry"
 	"github.com/jsleeio/go-eagle/pkg/panel"
 
 	"github.com/jsleeio/go-eagle/internal/boardops/standard"
@@ -140,52 +142,142 @@ func headerOp(plc panelLayoutContext) {
 	plc.panel.Board.Plain.Texts = append(plc.panel.Board.Plain.Texts, footer)
 }
 
+type elementConfig struct {
+	legendOffsetX, legendOffsetY   float64
+	legendLocationFactor           float64
+	legend                         string
+	ticks, ticksLabels             bool
+	ticksStartAngle, ticksEndAngle float64
+	ticksLength, ticksWidth        float64
+	ticksCount                     int
+	ticksLabelsTexts               []string
+}
+
+// extract all the per-element config into a nice structure. Later this should help
+// with refactoring the currently-ugly elementOp() into a bunch of separate operations
+func elementConfigFromElement(elem eagle.Element) (elementConfig, error) {
+	var err error
+	ec := elementConfig{
+		legend:           eagle.AttributeString(elem, "PANEL_LEGEND", elem.Name),
+		ticksLabelsTexts: strings.Split(eagle.AttributeString(elem, "PANEL_LEGEND_TICKS_LABELS_TEXTS", ""), ","),
+	}
+	if ec.legendOffsetX, err = eagle.AttributeFloat(elem, "PANEL_LEGEND_OFFSET_X", 0.0); err != nil {
+		return ec, err
+	}
+	if ec.legendOffsetY, err = eagle.AttributeFloat(elem, "PANEL_LEGEND_OFFSET_Y", 0.0); err != nil {
+		return ec, err
+	}
+	legendlocation := eagle.AttributeString(elem, "PANEL_LEGEND_LOCATION", "above")
+	switch legendlocation {
+	case "above":
+		ec.legendLocationFactor = 1
+	case "below":
+		ec.legendLocationFactor = -1
+	default:
+		return ec, fmt.Errorf("invalid value %q for attribute PANEL_LEGEND_LOCATION on object %q: must be 'above' or 'below'", legendlocation, elem.Name)
+	}
+	if ec.ticks, err = eagle.AttributeBool(elem, "PANEL_LEGEND_TICKS", false); err != nil {
+		return ec, err
+	}
+	if ec.ticksLabels, err = eagle.AttributeBool(elem, "PANEL_LEGEND_TICKS_LABELS", false); err != nil {
+		return ec, err
+	}
+	if ec.ticksLength, err = eagle.AttributeFloat(elem, "PANEL_LEGEND_TICKS_LENGTH", 1.5); err != nil {
+		return ec, err
+	}
+	if ec.ticksWidth, err = eagle.AttributeFloat(elem, "PANEL_LEGEND_TICKS_WIDTH", 0.25); err != nil {
+		return ec, err
+	}
+	// default values for start and end angles suit a typical single-turn potentiometer
+	// with a 270-degree rotation
+	if ec.ticksStartAngle, err = eagle.AttributeFloat(elem, "PANEL_LEGEND_TICKS_START_ANGLE", -45.0); err != nil {
+		return ec, err
+	}
+	if ec.ticksEndAngle, err = eagle.AttributeFloat(elem, "PANEL_LEGEND_TICKS_END_ANGLE", 225.0); err != nil {
+		return ec, err
+	}
+	// everything should go up to (at least) 11
+	if ec.ticksCount, err = eagle.AttributeInt(elem, "PANEL_LEGEND_TICKS_COUNT", 11); err != nil {
+		return ec, err
+	}
+	if ec.ticksLabels && len(ec.ticksLabelsTexts) != ec.ticksCount {
+		return ec, fmt.Errorf("incorrect number of tick labels provided for object %q: ticks = %v, labels = %v", elem.Name, ec.ticksCount, len(ec.ticksLabelsTexts))
+	}
+	log.Printf("element config for %s: %+v", elem.Name, ec)
+	return ec, nil
+}
+
 func elementOp(plc panelLayoutContext, elem eagle.Element) {
 	hole, needHole, err := holeForPanelElement(elem)
 	if err != nil {
 		log.Fatalf("can't find drill size for element %q: %v", elem.Name, err)
 	}
-	if needHole {
-		// the hole was generated with coordinates from the source board, now
-		// adjust them to be in the right place on the panel
-		tstop := plc.panel.LayerByName("tStop")
-		hole.X += plc.bc.XOffset
-		hole.Y += plc.bc.YOffset
-		aox, err := eagle.AttributeFloat(elem, "PANEL_LEGEND_OFFSET_X", 0.0)
-		if err != nil {
-			log.Fatal(err)
+	if !needHole {
+		return
+	}
+	// derive the per-element config
+	elementConfig, err := elementConfigFromElement(elem)
+	if err != nil {
+		log.Fatalf("error extracting per-element config from attributes: %v", err)
+	}
+	// the hole was generated with coordinates from the source board, now
+	// adjust them to be in the right place on the panel
+	tstop := plc.panel.LayerByName("tStop")
+	hole.X += plc.bc.XOffset
+	hole.Y += plc.bc.YOffset
+	plc.panel.Board.Plain.Holes = append(plc.panel.Board.Plain.Holes, hole)
+	text := eagle.Text{
+		X:     hole.X + elementConfig.legendOffsetX,
+		Y:     hole.Y + ((elementConfig.legendOffsetY + (hole.Drill / 2.0) + *plc.cfg.TextSpacing) * elementConfig.legendLocationFactor),
+		Size:  *plc.cfg.TextSize,
+		Layer: plc.panel.LayerByName(plc.legendLayer),
+		Text:  elementConfig.legend,
+		Align: "bottom-center",
+		Font:  "vector",
+	}
+	if text.Text != "" && (plc.legendSkipRe == nil || !plc.legendSkipRe.MatchString(elem.Name)) {
+		plc.panel.Board.Plain.Texts = append(plc.panel.Board.Plain.Texts, text)
+	} else {
+		log.Printf("%s: skipping legend\n", elem.Name)
+	}
+	hsw, err := eagle.AttributeFloat(elem, "PANEL_HOLE_STOP_WIDTH", *plc.cfg.HoleStopRadius)
+	if err != nil {
+		log.Fatal(err)
+	}
+	stop := eagle.Circle{
+		X: hole.X, Y: hole.Y,
+		Radius: hole.Drill / 2.0,
+		Width:  hsw,
+		Layer:  tstop,
+	}
+	plc.panel.Board.Plain.Circles = append(plc.panel.Board.Plain.Circles, stop)
+	if elementConfig.ticks {
+		rpg := geometry.RadialPointGenerator{
+			X: hole.X, Y: hole.Y,
+			StartAngle: elementConfig.ticksStartAngle,
+			EndAngle:   elementConfig.ticksEndAngle,
+			Count:      elementConfig.ticksCount,
 		}
-		aoy, err := eagle.AttributeFloat(elem, "PANEL_LEGEND_OFFSET_Y", 0.0)
-		if err != nil {
-			log.Fatal(err)
+		tickstarts := rpg.GenerateAtRadius(hole.Drill/2.0 + *plc.cfg.HoleStopRadius)
+		tickends := rpg.GenerateAtRadius(hole.Drill/2.0 + *plc.cfg.HoleStopRadius + elementConfig.ticksLength)
+		textorigins := rpg.GenerateAtRadius(hole.Drill/2.0 + *plc.cfg.HoleStopRadius + elementConfig.ticksLength + 2.0)
+		for index, inner := range tickstarts {
+			plc.panel.Board.Plain.Wires = append(plc.panel.Board.Plain.Wires, eagle.Wire{
+				X1: inner.X, Y1: inner.Y,
+				X2: tickends[index].X, Y2: tickends[index].Y,
+				Width: elementConfig.ticksWidth,
+				Layer: tstop,
+			})
+			if elementConfig.ticksLabels {
+				plc.panel.Board.Plain.Texts = append(plc.panel.Board.Plain.Texts, eagle.Text{
+					X: textorigins[index].X, Y: textorigins[index].Y,
+					Align: "center",
+					Size:  1.5,
+					Text:  strings.TrimSpace(elementConfig.ticksLabelsTexts[index]),
+					Layer: tstop,
+				})
+			}
 		}
-		plc.panel.Board.Plain.Holes = append(plc.panel.Board.Plain.Holes, hole)
-		text := eagle.Text{
-			X:     aox + hole.X,
-			Y:     aoy + hole.Y + (hole.Drill / 2.0) + *plc.cfg.TextSpacing,
-			Size:  *plc.cfg.TextSize,
-			Layer: plc.panel.LayerByName(plc.legendLayer),
-			Text:  eagle.AttributeString(elem, "PANEL_LEGEND", elem.Name),
-			Align: "bottom-center",
-			Font:  "vector",
-		}
-		if text.Text != "" && (plc.legendSkipRe == nil || !plc.legendSkipRe.MatchString(elem.Name)) {
-			plc.panel.Board.Plain.Texts = append(plc.panel.Board.Plain.Texts, text)
-		} else {
-			log.Printf("%s: skipping legend\n", elem.Name)
-		}
-		hsw, err := eagle.AttributeFloat(elem, "PANEL_HOLE_STOP_WIDTH", *plc.cfg.HoleStopRadius)
-		if err != nil {
-			log.Fatal(err)
-		}
-		stop := eagle.Circle{
-			X:      hole.X,
-			Y:      hole.Y,
-			Radius: hole.Drill / 2.0,
-			Width:  hsw,
-			Layer:  tstop,
-		}
-		plc.panel.Board.Plain.Circles = append(plc.panel.Board.Plain.Circles, stop)
 	}
 }
 

--- a/cmd/schroff/schroff.go
+++ b/cmd/schroff/schroff.go
@@ -26,11 +26,13 @@ import (
 	"log"
 	"path/filepath"
 	"regexp"
+	"strings"
 
 	"github.com/jsleeio/go-eagle/pkg/eagle"
 	"github.com/jsleeio/go-eagle/pkg/format/eurorack"
 	"github.com/jsleeio/go-eagle/pkg/format/intellijel"
 	"github.com/jsleeio/go-eagle/pkg/format/pulplogic"
+	filespec "github.com/jsleeio/go-eagle/pkg/format/spec"
 	"github.com/jsleeio/go-eagle/pkg/panel"
 
 	"github.com/jsleeio/go-eagle/internal/boardops/standard"
@@ -44,16 +46,19 @@ const (
 	FormatPulplogic = "pulplogic"
 	// FormatIntellijel is the Intellijel-defined 1U specification
 	FormatIntellijel = "intellijel"
+	// FormatSpec is the YAML-derived panel specification
+	FormatSpec = "spec"
 )
 
 // wrap up all of the context required for creating panel features
 // into one place to simplify and reduce error
 type panelLayoutContext struct {
-	bc    outline.BoardCoords
-	board *eagle.Eagle
-	panel *eagle.Eagle
-	cfg   config
-	spec  panel.Panel
+	format string
+	bc     outline.BoardCoords
+	board  *eagle.Eagle
+	panel  *eagle.Eagle
+	cfg    config
+	spec   panel.Panel
 	// legendSkipRe is pulled from the board global attribute PANEL_LEGEND_SKIP_RE.
 	// If a component name matches this regexp, it will NOT have a panel legend
 	// text object created.
@@ -61,6 +66,26 @@ type panelLayoutContext struct {
 	legendLayer  string
 	headerLayer  string
 	footerLayer  string
+}
+
+func (plc *panelLayoutContext) panelSpecForFormat() (err error) {
+	err = nil
+	switch *plc.cfg.Format {
+	case FormatEurorack:
+		plc.spec = eurorack.NewEurorack(plc.bc.HP)
+	case FormatPulplogic:
+		plc.spec = pulplogic.NewPulplogic(plc.bc.HP)
+	case FormatIntellijel:
+		plc.spec = intellijel.NewIntellijel(plc.bc.HP)
+	case FormatSpec:
+		plc.spec, err = filespec.LoadSpec(*plc.cfg.SpecFile)
+		if err != nil {
+			err = fmt.Errorf("error loading YAML panel spec from '%v': %v", *plc.cfg.SpecFile, err)
+		}
+	default:
+		err = fmt.Errorf("unsupported format: %s", *plc.cfg.Format)
+	}
+	return
 }
 
 func setupPanelLayoutContext(board *eagle.Eagle, c config) (panelLayoutContext, error) {
@@ -76,11 +101,10 @@ func setupPanelLayoutContext(board *eagle.Eagle, c config) (panelLayoutContext, 
 	if lsre := eagle.AttributeString(board.Board, "PANEL_LEGEND_SKIP_RE", ""); lsre != "" {
 		plc.legendSkipRe = regexp.MustCompile(lsre)
 	}
-	spec, err := panelSpecForFormat(plc.bc.HP, *plc.cfg.Format)
+	err := plc.panelSpecForFormat()
 	if err != nil {
 		return panelLayoutContext{}, err
 	}
-	plc.spec = spec
 	plc.panel = plc.board.CloneEmpty()
 	if err := standard.ApplyStandardBoardOperations(plc.panel, plc.spec); err != nil {
 		return panelLayoutContext{}, fmt.Errorf("error creating panel features: %v", err)
@@ -89,21 +113,6 @@ func setupPanelLayoutContext(board *eagle.Eagle, c config) (panelLayoutContext, 
 	plc.bc.XOffset += (plc.spec.Width()-plc.bc.Width())/2 + plc.spec.HorizontalFit()/2
 	plc.bc.YOffset += (plc.spec.Height() - plc.bc.Height()) / 2
 	return plc, nil
-}
-
-func panelSpecForFormat(width int, format string) (panel.Panel, error) {
-	var spec panel.Panel
-	switch format {
-	case FormatEurorack:
-		spec = eurorack.NewEurorack(width)
-	case FormatPulplogic:
-		spec = pulplogic.NewPulplogic(width)
-	case FormatIntellijel:
-		spec = intellijel.NewIntellijel(width)
-	default:
-		return nil, fmt.Errorf("unsupported format: %s", format)
-	}
-	return spec, nil
 }
 
 func headerOp(plc panelLayoutContext) {
@@ -120,18 +129,20 @@ func headerOp(plc panelLayoutContext) {
 		}
 	}
 	// add the header and footer
+	headerloc := plc.spec.HeaderLocation()
 	header := eagle.Text{
-		X:     plc.spec.Width()/2.0 + offsets["PANEL_HEADER_OFFSET_X"],
-		Y:     plc.spec.MountingHoleTopY() + offsets["PANEL_HEADER_OFFSET_Y"],
+		X:     headerloc.X + offsets["PANEL_HEADER_OFFSET_X"],
+		Y:     headerloc.Y + offsets["PANEL_HEADER_OFFSET_Y"],
 		Align: "center",
 		Size:  3.0,
 		Text:  eagle.AttributeString(plc.board.Board, "PANEL_HEADER_TEXT", "<HEADER>"),
 		Layer: plc.panel.LayerByName(plc.headerLayer),
 	}
+	footerloc := plc.spec.FooterLocation()
 	plc.panel.Board.Plain.Texts = append(plc.panel.Board.Plain.Texts, header)
 	footer := eagle.Text{
-		X:     plc.spec.Width()/2.0 + offsets["PANEL_FOOTER_OFFSET_X"],
-		Y:     plc.spec.MountingHoleBottomY() + offsets["PANEL_FOOTER_OFFSET_Y"],
+		X:     footerloc.X + offsets["PANEL_FOOTER_OFFSET_X"],
+		Y:     footerloc.Y + offsets["PANEL_FOOTER_OFFSET_Y"],
 		Align: "center",
 		Size:  3.0,
 		Text:  eagle.AttributeString(plc.board.Board, "PANEL_FOOTER_TEXT", "<FOOTER>"),
@@ -210,14 +221,17 @@ type config struct {
 	TextSpacing    *float64
 	TextSize       *float64
 	HoleStopRadius *float64
+	SpecFile       *string
 }
 
 func configureFromFlags() config {
+	formatList := "(" + strings.Join([]string{FormatEurorack, FormatPulplogic, FormatIntellijel, FormatSpec}, ",") + ")"
 	cfg := config{
-		Format:         flag.String("format", FormatEurorack, "panel format to create (eurorack, pulplogic, intellijel)"),
+		Format:         flag.String("format", FormatEurorack, "panel format to create "+formatList),
 		TextSpacing:    flag.Float64("text-spacing", 3.5, "spacing between a hole and its related label"),
 		TextSize:       flag.Float64("text-size", 2.25, "label text size"),
 		HoleStopRadius: flag.Float64("hole-stop-radius", 2.0, "Radius to pull back soldermask around a hole"),
+		SpecFile:       flag.String("spec-file", "", "filename to read YAML panel spec from"),
 	}
 	flag.Parse()
 	return cfg
@@ -230,7 +244,6 @@ func main() {
 		if err != nil {
 			log.Fatalf("can't load input file %q: %v", filename, err)
 		}
-		// panel, bc := schroffPanelForBoard(board, config)
 		plc, err := setupPanelLayoutContext(board, config)
 		if err != nil {
 			log.Fatalf("can't setup panel layout context: %v", err)

--- a/enclosures/spec-test.yaml
+++ b/enclosures/spec-test.yaml
@@ -1,0 +1,12 @@
+# note that this doesn't represent any actual enclosure; it only exists for testing!
+#
+name: testEnclosure
+width: 100.0
+height: 75.0
+horizontalFit: 0.0
+mountingHoleDiameter: 3.1
+mountingHoles:
+  - { x: 10, y: 10 }
+  - { x: 90, y: 10 }
+  - { x: 10, y: 65 }
+  - { x: 90, y: 65 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/jsleeio/go-eagle
 
 go 1.12
+
+require gopkg.in/yaml.v2 v2.2.8

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,3 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
+gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/internal/boardops/standard/standard.go
+++ b/internal/boardops/standard/standard.go
@@ -75,23 +75,30 @@ func mountingHolesOp(board *eagle.Eagle, spec panel.Panel) error {
 }
 
 func railKeepoutsOp(board *eagle.Eagle, spec panel.Panel) error {
-	layer := board.LayerByName("tKeepout")
-	bRail := eagle.Rectangle{
-		X1:    panel.LeftX(spec),
-		Y1:    spec.MountingHoleBottomY(),
-		X2:    panel.RightX(spec),
-		Y2:    spec.MountingHoleBottomY() + spec.RailHeightFromMountingHole(),
-		Layer: layer,
+	// format may not have rails.
+	// FIXME: find a better way to do this now that custom formats are
+	//        supported. Maybe add a new operation that creates keepouts
+	//        around panel holes to account for mounting hole posts in
+	//        typical off-the-shelf enclosures?
+	if railheight := spec.RailHeightFromMountingHole(); railheight > 0 {
+		layer := board.LayerByName("tKeepout")
+		bRail := eagle.Rectangle{
+			X1:    panel.LeftX(spec),
+			Y1:    spec.MountingHoleBottomY(),
+			X2:    panel.RightX(spec),
+			Y2:    spec.MountingHoleBottomY() + spec.RailHeightFromMountingHole(),
+			Layer: layer,
+		}
+		tRail := eagle.Rectangle{
+			X1:    panel.LeftX(spec),
+			Y1:    spec.MountingHoleTopY() - spec.RailHeightFromMountingHole(),
+			X2:    panel.RightX(spec),
+			Y2:    spec.MountingHoleTopY(),
+			Layer: layer,
+		}
+		board.Board.Plain.Rectangles = append(board.Board.Plain.Rectangles, bRail)
+		board.Board.Plain.Rectangles = append(board.Board.Plain.Rectangles, tRail)
 	}
-	tRail := eagle.Rectangle{
-		X1:    panel.LeftX(spec),
-		Y1:    spec.MountingHoleTopY() - spec.RailHeightFromMountingHole(),
-		X2:    panel.RightX(spec),
-		Y2:    spec.MountingHoleTopY(),
-		Layer: layer,
-	}
-	board.Board.Plain.Rectangles = append(board.Board.Plain.Rectangles, bRail)
-	board.Board.Plain.Rectangles = append(board.Board.Plain.Rectangles, tRail)
 	return nil
 }
 

--- a/pkg/format/eurorack/eurorack.go
+++ b/pkg/format/eurorack/eurorack.go
@@ -125,3 +125,15 @@ func (e Eurorack) MountingHoleTopY() float64 {
 func (e Eurorack) MountingHoleBottomY() float64 {
 	return MountingHoleBottomY3U
 }
+
+// HeaderLocation returns the location of the header text. Eurorack has
+// mounting rails so this is typically aligned with the top mounting screw
+func (e Eurorack) HeaderLocation() panel.Point {
+	return panel.Point{X: e.Width() / 2, Y: e.MountingHoleTopY()}
+}
+
+// FooterLocation returns the location of the footer text. Eurorack has
+// mounting rails so this is typically aligned with the bottom mounting screw
+func (e Eurorack) FooterLocation() panel.Point {
+	return panel.Point{X: e.Width() / 2, Y: e.MountingHoleBottomY()}
+}

--- a/pkg/format/intellijel/intellijel.go
+++ b/pkg/format/intellijel/intellijel.go
@@ -121,3 +121,16 @@ func (i Intellijel) MountingHoleTopY() float64 {
 func (i Intellijel) MountingHoleBottomY() float64 {
 	return MountingHoleBottomY1U
 }
+
+// HeaderLocation returns the location of the header text. Intellijel 1U has
+// mounting rails so this is typically aligned with the top mounting screw
+
+func (i Intellijel) HeaderLocation() panel.Point {
+	return panel.Point{X: i.Width() / 2.0, Y: i.MountingHoleTopY()}
+}
+
+// FooterLocation returns the location of the footer text. Intellijel 1U has
+// mounting rails so this is typically aligned with the bottom mounting screw
+func (i Intellijel) FooterLocation() panel.Point {
+	return panel.Point{X: i.Width() / 2.0, Y: i.MountingHoleBottomY()}
+}

--- a/pkg/format/pulplogic/pulplogic.go
+++ b/pkg/format/pulplogic/pulplogic.go
@@ -130,3 +130,15 @@ func (p Pulplogic) MountingHoleTopY() float64 {
 func (p Pulplogic) MountingHoleBottomY() float64 {
 	return MountingHoleBottomY1U
 }
+
+// HeaderLocation returns the location of the header text. Pulplogic 1U has
+// mounting rails so this is typically aligned with the top mounting screw
+func (p Pulplogic) HeaderLocation() panel.Point {
+	return panel.Point{X: p.Width() / 2.0, Y: p.MountingHoleTopY()}
+}
+
+// FooterLocation returns the location of the footer text. Pulplogic 1U has
+// mounting rails so this is typically aligned with the bottom mounting screw
+func (p Pulplogic) FooterLocation() panel.Point {
+	return panel.Point{X: p.Width() / 2.0, Y: p.MountingHoleBottomY()}
+}

--- a/pkg/format/spec/spec.go
+++ b/pkg/format/spec/spec.go
@@ -1,0 +1,125 @@
+// Copyright 2020 John Slee <jslee@jslee.io>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+
+package spec
+
+import (
+	"fmt"
+	"io/ioutil"
+	"sort"
+
+	"gopkg.in/yaml.v2"
+
+	"github.com/jsleeio/go-eagle/pkg/panel"
+)
+
+// Spec implements the panel.Panel interface and encapsulates the physical
+// characteristics of a Spec panel
+type Spec struct {
+	SpecName                 string        `yaml:"name"`
+	SpecWidth                float64       `yaml:"width"`
+	SpecHeight               float64       `yaml:"height"`
+	SpecMountingHoles        []panel.Point `yaml:"mountingHoles"`
+	SpecMountingHoleDiameter float64       `yaml:"mountingHoleDiameter"`
+	SpecHorizontalFit        float64       `yaml:"horizontalFit"`
+}
+
+type PanelSpecError struct {
+	s string
+}
+
+func (e *PanelSpecError) Error() string {
+	return fmt.Sprintf("PanelSpecError: %s", e.s)
+}
+
+func NewPanelSpecError(s string) error {
+	return &PanelSpecError{s: s}
+}
+
+// LoadSpec constructs a new Spec object according to a YAML file definition
+func LoadSpec(filename string) (*Spec, error) {
+	yamltext, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+	var sp Spec
+	if err := yaml.Unmarshal(yamltext, &sp); err != nil {
+		return nil, err
+	}
+	if len(sp.SpecMountingHoles) < 1 {
+		return nil, NewPanelSpecError("need at least one mounting hole")
+	}
+	sort.Slice(sp.SpecMountingHoles, func(i, j int) bool {
+		return sp.SpecMountingHoles[i].Y < sp.SpecMountingHoles[j].Y
+	})
+	return &sp, nil
+}
+
+// Width returns the width of a Spec panel, in millimetres
+func (s Spec) Width() float64 {
+	return s.SpecWidth
+}
+
+// Height returns the height of a Spec panel, in millimetres
+func (s Spec) Height() float64 {
+	return s.SpecHeight
+}
+
+// MountingHoleDiameter returns the Spec system mounting hole size, in
+// millimetres
+func (s Spec) MountingHoleDiameter() float64 {
+	return s.SpecMountingHoleDiameter
+}
+
+// MountingHoles generates a set of Point objects representing the mounting
+// hole locations of a Spec panel
+func (s Spec) MountingHoles() []panel.Point {
+	return s.SpecMountingHoles
+}
+
+// HorizontalFit indicates the panel tolerance adjustment for the format
+func (s Spec) HorizontalFit() float64 {
+	return s.SpecHorizontalFit
+}
+
+// RailHeightFromMountingHole doesn't really directly apply to YAML-spec
+// panels where the keepout area is more likely to be a ring around each
+// mounting hole, with the thickness of the ring likely varying with the
+// mounting hole diameter. For now, keep it simple and return 0. The PCB
+// designer will need to be careful regardless in order to fit their
+// design within the given enclosure's envelope.
+//
+// FIXME: fix the interface design here to better facilitate non-system
+//        panels (without making it unnecessarily awful!)
+func (s Spec) RailHeightFromMountingHole() float64 {
+	return 0.0
+}
+
+// MountingHoleTopY returns the Y coordinate for the top row of mounting
+// holes
+func (s Spec) MountingHoleTopY() float64 {
+	return s.SpecMountingHoles[0].Y
+}
+
+// MountingHoleBottomY returns the Y coordinate for the bottom row of
+// mounting holes
+func (s Spec) MountingHoleBottomY() float64 {
+	return s.SpecMountingHoles[len(s.SpecMountingHoles)-1].Y
+}

--- a/pkg/format/spec/spec.go
+++ b/pkg/format/spec/spec.go
@@ -123,3 +123,15 @@ func (s Spec) MountingHoleTopY() float64 {
 func (s Spec) MountingHoleBottomY() float64 {
 	return s.SpecMountingHoles[len(s.SpecMountingHoles)-1].Y
 }
+
+// HeaderLocation returns the location of the header text. Spec panels
+// may not have mounting rails so this is entirely arbitrary
+func (s Spec) HeaderLocation() panel.Point {
+	return panel.Point{X: s.Width() / 2, Y: s.MountingHoleTopY()}
+}
+
+// FooterLocation returns the location of the footer text. Spec panels
+// may not have mounting rails so this is entirely arbitrary
+func (s Spec) FooterLocation() panel.Point {
+	return panel.Point{X: s.Width() / 2, Y: s.MountingHoleBottomY()}
+}

--- a/pkg/geometry/geometry.go
+++ b/pkg/geometry/geometry.go
@@ -1,3 +1,23 @@
+// Copyright 2020 John Slee <jslee@jslee.io>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+
 package geometry
 
 import "math"

--- a/pkg/geometry/geometry.go
+++ b/pkg/geometry/geometry.go
@@ -1,0 +1,40 @@
+package geometry
+
+import "math"
+
+// Point holds a Cartesian point and also an angle in degrees.
+type RadialPoint struct {
+	Angle float64
+	X, Y  float64
+}
+
+// RadialPointGenerator generates a series of Cartesian points around a segment
+// of a circle.
+type RadialPointGenerator struct {
+	// StartAngle and EndAngle indicate the span in degrees around the circle for
+	// which points are generated. Zero degrees is at 9-o'clock and increases in
+	// the clockwise direction.
+	StartAngle, EndAngle float64
+	// X and Y indicate the centre of the circle (origin)
+	X, Y float64
+	// Count indicates how many ticks are generated
+	Count int
+}
+
+// GenerateAtRadius returns a set of evenly-distributed Cartesian points around
+// a circle at a supplied radius.
+func (rpg RadialPointGenerator) GenerateAtRadius(r float64) []RadialPoint {
+	var points []RadialPoint
+	interval := (rpg.EndAngle - rpg.StartAngle) / float64(rpg.Count-1)
+	for i := 0; i < rpg.Count; i++ {
+		angle := rpg.StartAngle + interval*float64(i)
+		radians := angle * math.Pi / 180.0
+		point := RadialPoint{
+			Angle: angle,
+			X:     rpg.X - r*math.Cos(radians),
+			Y:     rpg.Y + r*math.Sin(radians),
+		}
+		points = append(points, point)
+	}
+	return points
+}

--- a/pkg/panel/panel.go
+++ b/pkg/panel/panel.go
@@ -72,6 +72,12 @@ type Panel interface {
 	// MountingHoleBottomY returns the Y coordinate for the bottom row of
 	// mounting holes
 	MountingHoleBottomY() float64
+
+	// HeaderLocation returns the location of the header text
+	HeaderLocation() Point
+
+	// FooterLocation returns the location of the footer text
+	FooterLocation() Point
 }
 
 func LeftX(spec Panel) float64 {


### PR DESCRIPTION
addressing https://github.com/jsleeio/go-eagle/issues/4

* new 'spec' panel format, loaded from YAML
* support 'spec' format in 'panelgen' (but not 'schroff', yet)
* add enclosures folder with example YAML panel spec
* README update