### PR TITLE
add support for corner radius in panel format

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ files that look like the below:
     width: 100.0
     height: 75.0
     horizontalFit: 0.0
+    cornerRadius: 0.0
     mountingHoleDiameter: 3.1
     mountingHoles:
       - { x: 10, y: 10 }
@@ -152,7 +153,7 @@ Usage with `go-eagle`:
 
     $ ./go-eagle -format=spec -spec-file=enclosure.yaml test.brd
 
-This is extremely preliminary at presejt
+This is extremely preliminary at present.
 
 # panelgen
 
@@ -190,7 +191,6 @@ Usage of ./panelgen:
 # to-do
 
 * exhaustively scan the Eagle DTD and add the various missing items (libraries!)
-* panel corner radius support, to better fit common box enclosures
 * BOM generation tool
 * custom panel format should support defining a list of keepouts in at least
   rectangular and circular shapes
@@ -200,7 +200,7 @@ Usage of ./panelgen:
 
 # copyright
 
-Copyright 2020 John Slee <jslee@jslee.io>.
+Copyright 2021 John Slee <jslee@jslee.io>.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/enclosures/spec-test-cornerradius1.yaml
+++ b/enclosures/spec-test-cornerradius1.yaml
@@ -1,0 +1,13 @@
+# note that this doesn't represent any actual enclosure; it only exists for testing!
+#
+name: testEnclosure
+width: 100.0
+height: 75.0
+horizontalFit: 0.0
+cornerRadius: 2.0
+mountingHoleDiameter: 3.1
+mountingHoles:
+  - { x: 10, y: 10 }
+  - { x: 90, y: 10 }
+  - { x: 10, y: 65 }
+  - { x: 90, y: 65 }

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/jsleeio/go-eagle
 
 go 1.12
 
-require gopkg.in/yaml.v2 v2.2.8
+require gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,4 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
-gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/internal/boardops/util/util.go
+++ b/internal/boardops/util/util.go
@@ -25,11 +25,19 @@ import (
 )
 
 // WireRectangle generates a rectangle
-func WireRectangle(x1, y1, x2, y2 float64, layer int, width float64) []eagle.Wire {
-	return []eagle.Wire{
-		{X1: x1, Y1: y1, X2: x2, Y2: y1, Layer: layer, Width: width}, // bottom
-		{X1: x1, Y1: y2, X2: x2, Y2: y2, Layer: layer, Width: width}, // top
-		{X1: x1, Y1: y1, X2: x1, Y2: y2, Layer: layer, Width: width}, // left
-		{X1: x2, Y1: y1, X2: x2, Y2: y2, Layer: layer, Width: width}, // right
+func WireRectangle(x1, y1, x2, y2 float64, layer int, width float64, radius float64) []eagle.Wire {
+	segments := []eagle.Wire{
+		{X1: x1 + radius, Y1: y1, X2: x2 - radius, Y2: y1, Layer: layer, Width: width}, // bottom
+		{X1: x1 + radius, Y1: y2, X2: x2 - radius, Y2: y2, Layer: layer, Width: width}, // top
+		{X1: x1, Y1: y1 + radius, X2: x1, Y2: y2 - radius, Layer: layer, Width: width}, // left
+		{X1: x2, Y1: y1 + radius, X2: x2, Y2: y2 - radius, Layer: layer, Width: width}, // right
 	}
+	if radius > 0.0 {
+		segments = append(segments,
+			eagle.Wire{Curve: -90.0, Layer: layer, X1: x1 + radius, Y1: y1, X2: x1, Y2: y1 + radius, Width: width}, // bottom-left
+			eagle.Wire{Curve: -90.0, Layer: layer, X1: x1, Y1: y2 - radius, X2: x1 + radius, Y2: y2, Width: width}, // top-left
+			eagle.Wire{Curve: -90.0, Layer: layer, X1: x2 - radius, Y1: y2, X2: x2, Y2: y2 - radius, Width: width}, // top-right
+			eagle.Wire{Curve: -90.0, Layer: layer, X1: x2, Y1: y1 + radius, X2: x2 - radius, Y2: y1, Width: width}) // bottom-right
+	}
+	return segments
 }

--- a/pkg/eagle/types.go
+++ b/pkg/eagle/types.go
@@ -75,7 +75,7 @@ type Vertex struct {
 
 // Polygon object
 type Polygon struct {
-	Vertices []Vertex `xml:"vertices>vertex"`
+	Vertices []Vertex `xml:"vertex"`
 	Isolate  string   `xml:"isolate,omitempty"`
 	Pour     string   `xml:"pour,omitempty"`
 	Orphans  string   `xml:"orphans,omitempty"`

--- a/pkg/eagle/types.go
+++ b/pkg/eagle/types.go
@@ -53,7 +53,7 @@ type Wire struct {
 	Layer int     `xml:"layer,attr"`
 	Style string  `xml:"style,attr,omitempty"`
 	Cap   string  `xml:"cap,attr,omitempty"`
-	Curve string  `xml:"curve,attr,omitempty"`
+	Curve float64 `xml:"curve,attr,omitempty"`
 }
 
 // Rectangle object

--- a/pkg/eagle/types.go
+++ b/pkg/eagle/types.go
@@ -68,8 +68,9 @@ type Rectangle struct {
 
 // Vertex object, used only in Polygon
 type Vertex struct {
-	X float64 `xml:"x,attr"`
-	Y float64 `xml:"y,attr"`
+	X     float64 `xml:"x,attr"`
+	Y     float64 `xml:"y,attr"`
+	Curve float64 `xml:"curve,attr,omitempty"`
 }
 
 // Polygon object

--- a/pkg/format/eurorack/eurorack.go
+++ b/pkg/format/eurorack/eurorack.go
@@ -17,7 +17,6 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
-
 package eurorack
 
 import (
@@ -55,6 +54,10 @@ const (
 
 	// HorizontalFit indicates the panel tolerance adjustment for the format
 	HorizontalFit = 0.25
+
+	// CornerRadius indicates the corner radius for the format. Eurorack doesn't
+	// believe in such things.
+	CornerRadius = 0.0
 
 	// RailHeightFromMountingHole is used to determine how much space exists.
 	// See discussion in github.com/jsleeio/pkg/panel. 5mm is a good safe
@@ -107,6 +110,11 @@ func (e Eurorack) MountingHoles() []panel.Point {
 // HorizontalFit indicates the panel tolerance adjustment for the format
 func (e Eurorack) HorizontalFit() float64 {
 	return HorizontalFit
+}
+
+// CornerRadius indicates the corner radius for the format
+func (e Eurorack) CornerRadius() float64 {
+	return CornerRadius
 }
 
 // RailHeightFromMountingHole is used to calculate space between rails

--- a/pkg/format/intellijel/intellijel.go
+++ b/pkg/format/intellijel/intellijel.go
@@ -54,6 +54,10 @@ const (
 	// HorizontalFit indicates the panel tolerance adjustment for the format
 	HorizontalFit = 0.25
 
+	// CornerRadius indicates the corner radius for the format. Eurorack doesn't
+	// believe in such things.
+	CornerRadius = 0.0
+
 	// RailHeightFromMountingHole is used to determine how much space exists.
 	// See discussion in github.com/jsleeio/pkg/panel. 5mm is a good safe
 	// figure for all known-used Eurorack rail types
@@ -103,6 +107,11 @@ func (i Intellijel) MountingHoles() []panel.Point {
 // HorizontalFit indicates the panel tolerance adjustment for the format
 func (i Intellijel) HorizontalFit() float64 {
 	return HorizontalFit
+}
+
+// CornerRadius indicates the corner radius for the format
+func (i Intellijel) CornerRadius() float64 {
+	return CornerRadius
 }
 
 // RailHeightFromMountingHole is used to calculate space between rails

--- a/pkg/format/pulplogic/pulplogic.go
+++ b/pkg/format/pulplogic/pulplogic.go
@@ -60,6 +60,10 @@ const (
 	// HorizontalFit indicates the panel tolerance adjustment for the format
 	HorizontalFit = eurorack.HorizontalFit
 
+	// CornerRadius indicates the corner radius for the format. Eurorack doesn't
+	// believe in such things.
+	CornerRadius = 0.0
+
 	// RailHeightFromMountingHole is used to determine how much space exists.
 	// See discussion in github.com/jsleeio/pkg/panel.
 	//
@@ -112,6 +116,11 @@ func (p Pulplogic) MountingHoles() []panel.Point {
 // HorizontalFit indicates the panel tolerance adjustment for the format
 func (p Pulplogic) HorizontalFit() float64 {
 	return HorizontalFit
+}
+
+// CornerRadius indicates the corner radius for the format
+func (p Pulplogic) CornerRadius() float64 {
+	return CornerRadius
 }
 
 // RailHeightFromMountingHole is used to calculate space between rails

--- a/pkg/format/spec/spec.go
+++ b/pkg/format/spec/spec.go
@@ -39,6 +39,7 @@ type Spec struct {
 	SpecMountingHoles        []panel.Point `yaml:"mountingHoles"`
 	SpecMountingHoleDiameter float64       `yaml:"mountingHoleDiameter"`
 	SpecHorizontalFit        float64       `yaml:"horizontalFit"`
+	SpecCornerRadius         float64       `yaml:"cornerRadius"`
 }
 
 type PanelSpecError struct {
@@ -97,6 +98,12 @@ func (s Spec) MountingHoles() []panel.Point {
 // HorizontalFit indicates the panel tolerance adjustment for the format
 func (s Spec) HorizontalFit() float64 {
 	return s.SpecHorizontalFit
+}
+
+// HorizontalFit indicates the corner radius for the format, as would be
+// useful for snugly fitting jiffyboxes. Default is no radius.
+func (s Spec) CornerRadius() float64 {
+	return s.SpecCornerRadius
 }
 
 // RailHeightFromMountingHole doesn't really directly apply to YAML-spec

--- a/pkg/panel/panel.go
+++ b/pkg/panel/panel.go
@@ -54,6 +54,11 @@ type Panel interface {
 	// of the panel. (and especially not the mounting holes!)
 	HorizontalFit() float64
 
+	// CornerRadius returns the radius of the panel corners, if applicable. A
+	// zero value will result in no corner segments being generated, and so the
+	// board outline will consist of four straight lines.
+	CornerRadius() float64
+
 	// RailHeightFromMountingHole indicates how far up (from centre of bottom
 	// mounting hole) or down (from centre of top mounting hole) the mounting
 	// rail extends. This can be used to define KeepOut areas on the panel


### PR DESCRIPTION
tick off a TODO item that's been lurking in the README for a while.

this should make the `spec` format significantly more useful, as panels can now conform neatly to the inside of jiffyboxes and the like, which tend to have rounded corners.